### PR TITLE
feat: remove install step as it might interfere with other setups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,10 +60,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install dependencies
-      run: npm install
-      shell: bash
-
     - name: Validate inputs
       run: |
         if [ "${{ inputs.destination }}" != "simulator" ] && [ "${{ inputs.destination }}" != "device" ]; then


### PR DESCRIPTION
In our case we use pnpm, this step was trying to install all dependencies from main package.json as well, causing it to fail due to not resolved dependencies.
I think it would be better to allow handling dependency installation outside, like in the android workflow.
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/f423517b-20fd-4e0c-9945-59ef5993f465" />
