### PR TITLE
feat: re-bundle APP when for simulator destinations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -253,8 +253,9 @@ runs:
 
         tar -C "$APP_DIR" -xzf "$APP_PATH"
         EXTRACTED_APP=$(find "$APP_DIR" -name "*.app" -type d | head -1)
-        ARTIFACT_PATH="$EXTRACTED_APP"
-        echo "ARTIFACT_PATH=$ARTIFACT_PATH" >> $GITHUB_ENV
+
+        echo "ARTIFACT_PATH=$APP_PATH" >> $GITHUB_ENV
+        echo "ARTIFACT_TAR_PATH=$EXTRACTED_APP" >> $GITHUB_ENV
       shell: bash
 
     - name: Re-sign IPA
@@ -269,7 +270,7 @@ runs:
     - name: Re-bundle APP
       if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
       run: |
-        npx rnef sign:ios ${{ env.ARTIFACT_PATH }} \
+        npx rnef sign:ios ${{ env.ARTIFACT_TAR_PATH }} \
           --build-jsbundle \
           --app
       shell: bash
@@ -282,6 +283,7 @@ runs:
         ARTIFACT_TRAITS_HYPHENATED=$(echo "$ARTIFACT_TRAITS" | tr ',' '-')
         ARTIFACT_TRAITS_HYPHENATED_FINGERPRINT="${ARTIFACT_TRAITS_HYPHENATED}-${FINGERPRINT}"
         echo "ARTIFACT_NAME=rnef-ios-${ARTIFACT_TRAITS_HYPHENATED_FINGERPRINT}" >> $GITHUB_ENV
+        echo "ARTIFACT_TRAITS=$ARTIFACT_TRAITS" >> $GITHUB_ENV
       shell: bash
 
     # Find artifact URL again before uploading, as other concurrent workflows could upload the same artifact


### PR DESCRIPTION
This change allows for re-signing (or rather re-bundling with fresh JS, as there's no signing step) APP bundles for simulators.

Example:
```yaml
- name: RNEF Remote Build - iOS simulator
  uses: callstackincubator/ios@feat/rebundle-app
  with:
    destination: simulator
    configuration: Release
    re-sign: true
```

cc @janicduplessis