### PR TITLE
Support re-sign on regular commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -283,7 +283,7 @@ runs:
       shell: bash
 
     - name: Download and Unpack IPA
-      if: ${{ env.ARTIFACT_URL && inputs.destination == 'device' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ env.ARTIFACT_URL && inputs.destination == 'device' && inputs.re-sign == 'true' }}
       run: |
         DOWNLOAD_OUTPUT=$(npx rock remote-cache download --name ${{ env.ARTIFACT_NAME }} --json) || (echo "$DOWNLOAD_OUTPUT" && exit 1)
         IPA_PATH=$(echo "$DOWNLOAD_OUTPUT" | jq -r '.path')
@@ -291,7 +291,7 @@ runs:
       shell: bash
 
     - name: Download and Unpack APP
-      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' }}
       run: |
         DOWNLOAD_OUTPUT=$(npx rock remote-cache download --name ${{ env.ARTIFACT_NAME }} --json) || (echo "$DOWNLOAD_OUTPUT" && exit 1)
         APP_PATH=$(echo "$DOWNLOAD_OUTPUT" | jq -r '.path')
@@ -306,7 +306,7 @@ runs:
       shell: bash
 
     - name: Re-sign IPA
-      if: ${{ env.ARTIFACT_URL && inputs.destination == 'device' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ env.ARTIFACT_URL && inputs.destination == 'device' && inputs.re-sign == 'true' }}
       run: |
         npx rock sign:ios ${{ env.ARTIFACT_PATH }} \
           --build-jsbundle \
@@ -315,7 +315,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Re-bundle APP
-      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' }}
       run: |
         npx rock sign:ios ${{ env.ARTIFACT_TAR_PATH }} \
           --build-jsbundle \
@@ -324,9 +324,14 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Update Artifact Name for re-signed builds
-      if: ${{ github.event_name == 'pull_request' && inputs.re-sign == 'true' }}
+      if: ${{ env.ARTIFACT_URL && inputs.re-sign == 'true' }}
       run: |
-        ARTIFACT_TRAITS="${{ inputs.destination }},${{ inputs.configuration }},${{ github.event.pull_request.number}}"
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          IDENTIFIER="${{ github.event.pull_request.number }}"
+        else
+          IDENTIFIER="${{ github.sha }}"
+        fi
+        ARTIFACT_TRAITS="${{ inputs.destination }},${{ inputs.configuration }},${IDENTIFIER}"
         ARTIFACT_TRAITS_HYPHENATED=$(echo "$ARTIFACT_TRAITS" | tr ',' '-')
         ARTIFACT_TRAITS_HYPHENATED_FINGERPRINT="${ARTIFACT_TRAITS_HYPHENATED}-${FINGERPRINT}"
         echo "ARTIFACT_NAME=rock-ios-${ARTIFACT_TRAITS_HYPHENATED_FINGERPRINT}" >> $GITHUB_ENV
@@ -348,7 +353,7 @@ runs:
     # Special case for GitHub, as it doesn't support uploading through the API
     - name: Upload Artifact to GitHub
       id: upload-artifact
-      if: ${{ env.PROVIDER_NAME == 'GitHub' && (!env.ARTIFACT_URL || (inputs.re-sign == 'true' && github.event_name == 'pull_request')) }}
+      if: ${{ env.PROVIDER_NAME == 'GitHub' && (!env.ARTIFACT_URL || inputs.re-sign == 'true') }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ env.ARTIFACT_NAME }}
@@ -358,7 +363,7 @@ runs:
     # For re-signed builds, the ARTIFACT_NAME may contain PR-number, while Rock will save the artifact without PR trait in its cache.
     # We need to upload the artifact with the PR-number in the name, that's why we use --binary-path with appropriate ARTIFACT_PATH that accounts for it.
     - name: Upload Artifact to Remote Cache for re-signed builds
-      if: ${{ env.PROVIDER_NAME != 'GitHub' && (inputs.re-sign == 'true' && github.event_name == 'pull_request') }}
+      if: ${{ env.PROVIDER_NAME != 'GitHub' && inputs.re-sign == 'true' }}
       run: |
         OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --binary-path ${{ env.ARTIFACT_PATH }} --json) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -370,7 +370,7 @@ runs:
       shell: bash
 
     - name: Upload Artifact to Remote Cache for regular builds
-      if: ${{ env.PROVIDER_NAME != 'GitHub' && !env.ARTIFACT_URL }}
+      if: ${{ env.PROVIDER_NAME != 'GitHub' && inputs.re-sign != 'true' && !env.ARTIFACT_URL }}
       run: |
         OUTPUT=$(npx rock remote-cache upload --name ${{ env.ARTIFACT_NAME }} --json) || (echo "$OUTPUT" && exit 1)
         echo "ARTIFACT_URL=$(echo "$OUTPUT" | jq -r '.url')" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -329,7 +329,7 @@ runs:
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           IDENTIFIER="${{ github.event.pull_request.number }}"
         else
-          IDENTIFIER="${{ github.sha }}"
+          IDENTIFIER=$(echo "$GITHUB_SHA" | cut -c1-7)
         fi
         ARTIFACT_TRAITS="${{ inputs.destination }},${{ inputs.configuration }},${IDENTIFIER}"
         ARTIFACT_TRAITS_HYPHENATED=$(echo "$ARTIFACT_TRAITS" | tr ',' '-')


### PR DESCRIPTION
Currently if we're using the re-sign argument on a regular commit, that build is never uploaded and no artifiact output is set. This handles re-sign outside pull requests by removing a few if pull_request and making sure we give a unique artifact name when uploading the re-signed build. Here we do not want to update the main artifact as it could cause race conditions for concurrent builds.