### PR TITLE
fix: repack re-bundled simulator .app on non-PR events

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -431,7 +431,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Repack APP into tar.gz
-      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' && github.event_name == 'pull_request' }}
+      if: ${{ env.ARTIFACT_URL && inputs.destination == 'simulator' && inputs.re-sign == 'true' }}
       run: |
         APP_DIR=$(dirname "$ARTIFACT_TAR_PATH")
         APP_BASENAME=$(basename "$ARTIFACT_TAR_PATH")


### PR DESCRIPTION
#15 added support for re-sign on regular commits, and #22 added the missing repack step for simulator builds, but scoped it to pull_request events only.

On **push** events with a remote-cache hit, however, the flow is currently:
1. The cached app.tar.gz is downloaded and extracted
2. rock sign:ios --build-jsbundle --app rebuilds a fresh JS bundle into the extracted .app
3. The repack step is skipped (PR-only condition), so ARTIFACT_PATH still points to the stale downloaded tar.gz
4. That stale archive is uploaded under the new commit-sha artifact name

So push-event consumers (e.g. E2E suites running against the artifact on the main branch) test an outdated JS bundle, which is the issue we're seeing at Rainbow in our current CI setup.

To fix it, this change aligns the repack condition with the preceding "Re-bundle APP" step, so the re-bundled `.app` is always repacked before upload regardless of trigger. We've been running this patch from a fork in [rainbow-me/rainbow](https://github.com/rainbow-me/rock-ios/tree/fix/repack-app-on-push) and confirmed push-event runs now repack and test the fresh bundle ([example run](https://github.com/rainbow-me/rainbow/actions/runs/27301099057)).